### PR TITLE
PRSummarizer to return typed response instead of str

### DIFF
--- a/perfeed/models/pr_summary.py
+++ b/perfeed/models/pr_summary.py
@@ -43,7 +43,7 @@ class CommentDescription(BaseModel):
     )
 
 
-class PRDescription(BaseModel):
+class PRSummary(BaseModel):
     type: list[PRType] = Field(
         description="one or more types that describe the PR content. Return the label member value (e.g. 'Bug fix', not 'bug_fix')"
     )

--- a/perfeed/settings/pr_summary_prompts.toml
+++ b/perfeed/settings/pr_summary_prompts.toml
@@ -9,9 +9,9 @@ Your task is to provide a full description for the PR based on the user provided
 
 Keep the output concise so it's easy to read and understand.
 
-The output must be a JSON object equivalent to type $PRDescription, according to the following definitions:
+The output must be a JSON object equivalent to type $PRSummary, according to the following definitions:
 ===
-{{PRDescription}}
+{{PRSummary}}
 ===
 
 Example output:


### PR DESCRIPTION
- rename `PRDescription` to `PRSummary` class to better align with its purpose as return type from `PRSummarizer`
- dump json str to `PRSummary` model before returned from `PRSummarizer`