### PR TITLE
refactor list_pr_numbers func in git provider with tests

### DIFF
--- a/perfeed/git_providers/base.py
+++ b/perfeed/git_providers/base.py
@@ -20,6 +20,6 @@ class BaseGitProvider(ABC):
 
     @abstractmethod
     async def list_pr_numbers(
-        self, owner: str, repo_name: str, start_date: datetime, end_date: datetime
+        self, repo_name: str, start_date: datetime, end_date: datetime, closed_only: bool = True
     ) -> list[int]:
         pass


### PR DESCRIPTION
1. refactor the signature to be ` async def list_pr_numbers(self, repo_name: str, start_date: datetime, end_date: datetime, closed_only: bool = True) -> list[int]:`
2. fix an issue where the result can be empty if the first page is outside the range of [start, end] but the results are in the next page
3. add unit tests