### PR TITLE
Add a simple implementation for WeeklySummarizer to wire up end to end flows

### DIFF
--- a/perfeed/config_loader.py
+++ b/perfeed/config_loader.py
@@ -7,6 +7,7 @@ settings = Dynaconf(
         os.path.join(current_dir, f)
         for f in [
             "settings/pr_summary_prompts.toml",
+            "settings/weekly_summary_prompts.toml",
         ]
     ]
 )

--- a/perfeed/git_providers/github.py
+++ b/perfeed/git_providers/github.py
@@ -200,7 +200,7 @@ class GithubProvider(BaseGitProvider):
                 pr["number"]
                 for pr in prs
                 if start_date
-                <= datetime.strptime(pr["created_at"], "%Y-%m-%dT%H:%M:%SZ")
+                <= datetime.strptime(pr["created_at"], "%Y-%m-%dT%H:%M:%S%z")
                 <= end_date
             ]
 
@@ -215,7 +215,7 @@ class GithubProvider(BaseGitProvider):
             ##      start_date                    end_date
             if (
                 len(prs) == 0
-                or datetime.strptime(prs[-1]["created_at"], "%Y-%m-%dT%H:%M:%SZ")
+                or datetime.strptime(prs[-1]["created_at"], "%Y-%m-%dT%H:%M:%S%z")
                 < start_date
             ):
                 break

--- a/perfeed/llms/ollama_client.py
+++ b/perfeed/llms/ollama_client.py
@@ -1,12 +1,10 @@
-from typing import Any, Dict
-
 import ollama
 
 from .base_client import BaseClient
 
 
 class OllamaClient(BaseClient):
-    def __init__(self, model: str):        
+    def __init__(self, model: str):
         self.model = model
         super().__init__()
 
@@ -37,7 +35,7 @@ class OllamaClient(BaseClient):
                 {"role": "user", "content": user},
             ],
             options={
-                "num_ctx": kwargs.get("num_ctx", 4096 * 2),
+                "num_ctx": kwargs.get("num_ctx", 1024 * 32),
                 "temperature": kwargs.get("temperature", 0),
             },
         )

--- a/perfeed/models/pr_summary.py
+++ b/perfeed/models/pr_summary.py
@@ -16,7 +16,7 @@ class FileDescription(BaseModel):
     filename: str = Field(description="The full file path of the relevant file.")
     language: str = Field(description="The programming language of the relevant file.")
     changes_summary: str = Field(
-        description="concise summary of the changes in the relevant file, in bullet points (1-4 bullet points)."
+        description="a concise summary of the changes in the relevant file, describing in 1-3 sentences."
     )
     changes_title: str = Field(
         description="an informative title for the changes in the files, describing its main theme (5-10 words)."
@@ -51,7 +51,7 @@ class PRSummary(BaseModel):
         description="an informative title for the PR, describing its main theme"
     )
     description: str = Field(
-        description="an informative and concise description of the PR. Use bullet points. Display first the most significant changes."
+        description="an informative and concise description of the PR. Highlight the most significant changes."
     )
     pr_files: list[FileDescription] = Field(
         max_length=15,
@@ -69,7 +69,7 @@ class PRSummary(BaseModel):
 
 class PRSummaryMetadata(BaseModel):
     "for metadata purpose. separated from PRSummary. which serves for not only as a data model but a prompt."
-    repo: str 
+    repo: str
     author: str
     pr_number: int
     llm_provider: str

--- a/perfeed/settings/pr_summary_prompts.toml
+++ b/perfeed/settings/pr_summary_prompts.toml
@@ -69,6 +69,6 @@ PR comments:
 '{{comments}}'
 ======
 
-Response (should be a valid json, and nothing else):
+Response (should be a valid PRSummary json, and nothing else):
 ```json
 """

--- a/perfeed/settings/weekly_summary_prompts.toml
+++ b/perfeed/settings/weekly_summary_prompts.toml
@@ -1,0 +1,31 @@
+[weekly_summary_prompt]
+
+system = """\
+You're a scrum master. You're in charge of the team weekly standup.
+Your job is to give a good summary of everyone's work based on their pull request summary (PRSummary).
+
+A single PRSummary is defined by the below pydantic definition:
+{{PRSummary}} 
+
+- Focus on the high level changes; highlight the most important things that were done.
+- When quoting variables or names from the code, use backticks (`) instead of single quote (').
+- Use bullet points (-) to list things, each in a new line.
+
+An example of the output is below:
+=====
+Here's a summary of the team's pull requests:
+- fix a bug that caused ...
+- add a new feature to help ...
+- refactor some legacy code to make ...
+- document some files ...
+=====
+
+Keep the output concise so it's easy to read and understand.
+"""
+
+user = """\
+Here's the pull requests from the team, given as a list of PRSummary.
+=====
+{{pr_summaries}}
+=====
+"""

--- a/perfeed/tools/pr_summarizer.py
+++ b/perfeed/tools/pr_summarizer.py
@@ -1,17 +1,15 @@
-import json
 import asyncio
+import json
+
 import requests
 from jinja2 import Environment, StrictUndefined
 
 from perfeed.config_loader import settings
-from perfeed.git_providers.github import GithubProvider
 from perfeed.git_providers.base import BaseGitProvider
+from perfeed.git_providers.github import GithubProvider
 from perfeed.llms.base_client import BaseClient
-from perfeed.llms.ollama_client import OllamaClient
-from perfeed.models.pr_summary import PRSummary, PRSummaryMetadata
+from perfeed.models.pr_summary import PRSummary
 from perfeed.utils import json_output_curator
-from datetime import datetime, timezone
-from typing import Tuple
 
 
 class PRSummarizer:
@@ -19,7 +17,7 @@ class PRSummarizer:
         self.git = git
         self.llm = llm
 
-    async def run(self, repo: str, pr_number: int) -> Tuple[PRSummary, PRSummaryMetadata]:
+    async def run(self, repo: str, pr_number: int) -> PRSummary:
         pr = await self.git.get_pr(repo, pr_number)
 
         self.variables = {
@@ -41,23 +39,21 @@ class PRSummarizer:
 
         summary = self.llm.chat_completion(system_prompt, user_prompt)
         curated_summary = json_output_curator(summary)
+
+        print(f"Summary of PR {pr.number}: \n{curated_summary}\n")
+
         pr_summary = PRSummary(**json.loads(curated_summary))
-        current_time = datetime.now(timezone.utc)
-        pr_metadata = PRSummaryMetadata(
-            repo = repo,
-            author = pr.author,
-            pr_number = pr_number,
-            llm_provider = self.llm.__class__.__name__,
-            model = self.llm.model,
-            pr_created_at = pr.created_at,
-            pr_merged_at = pr.merged_at,
-            created_at = current_time.strftime("%Y-%m-%dT%H:%M:%SZ")
-        )        
-        return pr_summary, pr_metadata
+
+        return pr_summary
 
 
 if __name__ == "__main__":
-    summarizer = PRSummarizer(GithubProvider("Perfeed"), llm=OllamaClient("llama3.2"))
-    pr_summary, metadata = asyncio.run(summarizer.run("perfeed", 5))
-    print(metadata)
+    from perfeed.llms.ollama_client import OllamaClient
+    from perfeed.llms.openai_client import OpenAIClient
+
+    summarizer = PRSummarizer(
+        GithubProvider("Perfeed"), llm=OllamaClient("llama3.1:8b")
+    )
+    # summarizer = PRSummarizer(GithubProvider("Perfeed"), llm=OpenAIClient("gpt-4o-mini"))
+    pr_summary = asyncio.run(summarizer.run("perfeed", 13))
     print(pr_summary)

--- a/perfeed/tools/weekly_summarizer.py
+++ b/perfeed/tools/weekly_summarizer.py
@@ -1,0 +1,98 @@
+import asyncio
+import time
+from datetime import datetime, timedelta
+
+from jinja2 import Environment, StrictUndefined
+
+from perfeed.config_loader import settings
+from perfeed.git_providers.base import BaseGitProvider
+from perfeed.git_providers.github import GithubProvider
+from perfeed.llms.base_client import BaseClient
+from perfeed.llms.ollama_client import OllamaClient
+from perfeed.models.pr_summary import PRSummary
+from perfeed.tools.pr_summarizer import PRSummarizer
+from perfeed.utils.utils import json_output_curator
+
+
+# python perfeed.py -users jimmytai chihangwang -repo perfeed-backend -period 1w
+class WeeklySummarizer:
+    def __init__(self, git: BaseGitProvider, summarizer: PRSummarizer, llm: BaseClient):
+        self.git = git
+        self.summarizer = summarizer
+        self.llm = llm
+
+    async def run(self, users: list[str], repo_name: str, start_of_week: str) -> None:
+
+        # Check if start_of_week must be the Sunday or Monday of the week
+        try:
+            date = datetime.strptime(start_of_week, "%Y-%m-%d")
+        except ValueError:
+            raise ValueError("Invalid date format. Please use 'YYYY-MM-DD'.")
+
+        # Check if the day of the week is Monday (0) or Sunday (-1)
+        if date.weekday() not in [0, 6]:
+            raise ValueError("Start day must be a Sunday or Monday.")
+
+        # Use local timezone by default
+        start_date = date.astimezone()
+        end_date = start_date + timedelta(days=6)
+
+        print(f"Summarizing {repo_name} for {users} from {start_date} to {end_date}")
+
+        now = time.perf_counter()
+        # TODO: filter results by users
+        pr_numbers = await self.git.list_pr_numbers(
+            repo_name, start_date, end_date, True
+        )
+
+        print(f"Summarizing the following PR-{pr_numbers}")
+
+        summary_futures = [
+            self.summarizer.run(repo_name, pr_number) for pr_number in pr_numbers
+        ]
+
+        summaries = await asyncio.gather(*summary_futures, return_exceptions=True)
+
+        elapsed = time.perf_counter() - now
+        print(f"Summarized {len(summaries)} PRs in {elapsed:0.5f} seconds")
+
+        # TODO: store PRSummary results so we don't have to re-process again
+
+        # TODO: handle failed summary futures with BaseException
+        json_summaries = [
+            summary.model_dump_json()
+            for summary in summaries
+            if not isinstance(summary, BaseException)
+        ]
+
+        self.variables = {
+            "PRSummary": PRSummary.to_json_schema(),
+            "pr_summaries": json_summaries,
+        }
+
+        environment = Environment(undefined=StrictUndefined)
+        system_prompt = environment.from_string(
+            settings.weekly_summary_prompt.system
+        ).render(self.variables)
+        user_prompt = environment.from_string(
+            settings.weekly_summary_prompt.user
+        ).render(self.variables)
+
+        summary = self.llm.chat_completion(system_prompt, user_prompt)
+        curated_summary = json_output_curator(summary)
+
+        print(f"Summary of the Week: \n{curated_summary}\n")
+
+
+if __name__ == "__main__":
+    git = GithubProvider("Perfeed")
+    summarizer = PRSummarizer(git=git, llm=OllamaClient("llama3.1:8b"))
+    llm = OllamaClient("llama3.1:8b")
+    weekly_summarizer = WeeklySummarizer(git=git, summarizer=summarizer, llm=llm)
+    asyncio.run(
+        weekly_summarizer.run(
+            users=["jimmytai", "chihangwang"],
+            repo_name="perfeed",
+            start_of_week="2024-10-21",
+        )
+    )

--- a/perfeed/tools/weekly_summarizer.py
+++ b/perfeed/tools/weekly_summarizer.py
@@ -47,6 +47,8 @@ class WeeklySummarizer:
 
         print(f"Summarizing the following PR-{pr_numbers}")
 
+        # TODO: load the PR summaries from the pervious batch if exists.
+
         summary_futures = [
             self.summarizer.run(repo_name, pr_number) for pr_number in pr_numbers
         ]

--- a/tests/test_github_provider.py
+++ b/tests/test_github_provider.py
@@ -25,7 +25,7 @@ class TestGithubProvider(unittest.TestCase):
             {
                 "id": 1,
                 "user": {"login": "test_user", "type": "User"},
-                "created_at": "2023-10-01T10:00:00Z",
+                "created_at": "2023-10-01T10:00:00+08:00",
                 "body": "Test issue comment",
                 "html_url": "http://example.com/comment/1",
             }
@@ -49,7 +49,7 @@ class TestGithubProvider(unittest.TestCase):
             {
                 "id": 2,
                 "user": {"login": "review_user", "type": "User"},
-                "created_at": "2023-10-01T11:00:00Z",
+                "created_at": "2023-10-01T11:00:00+08:00",
                 "body": "Test review comment",
                 "html_url": "http://example.com/comment/2",
             }
@@ -73,7 +73,7 @@ class TestGithubProvider(unittest.TestCase):
             {
                 "id": 1,
                 "user": {"login": "test_user", "type": "User"},
-                "created_at": "2023-10-01T10:00:00Z",
+                "created_at": "2023-10-01T10:00:00+08:00",
                 "body": "Issue comment",
                 "html_url": "http://example.com/comment/1",
             }
@@ -82,7 +82,7 @@ class TestGithubProvider(unittest.TestCase):
             {
                 "id": 2,
                 "user": {"login": "review_user", "type": "User"},
-                "created_at": "2023-10-01T11:00:00Z",
+                "created_at": "2023-10-01T11:00:00+08:00",
                 "body": "Review comment",
                 "html_url": "http://example.com/comment/2",
             }
@@ -91,8 +91,8 @@ class TestGithubProvider(unittest.TestCase):
         comments = asyncio.run(self.github_provider.list_pr_comments("test_repo", 1))
 
         self.assertEqual(len(comments), 2)
-        self.assertEqual(comments[0].created_at, "2023-10-01T10:00:00Z")
-        self.assertEqual(comments[1].created_at, "2023-10-01T11:00:00Z")
+        self.assertEqual(comments[0].created_at, "2023-10-01T10:00:00+08:00")
+        self.assertEqual(comments[1].created_at, "2023-10-01T11:00:00+08:00")
 
     def test_fetch_pr(self):
         """
@@ -103,7 +103,7 @@ class TestGithubProvider(unittest.TestCase):
             "title": "Test PR",
             "user": {"login": "author"},
             "state": "open",
-            "created_at": "2023-10-01T10:00:00Z",
+            "created_at": "2023-10-01T10:00:00+08:00",
             "body": "This is a test pull request.",
             "html_url": "http://example.com/pr/123",
             "diff_url": "http://example.com/diff",
@@ -125,8 +125,8 @@ class TestGithubProvider(unittest.TestCase):
                 state="open",
                 author="author",
                 reviewers=["reviewer1"],
-                created_at="2023-10-01T10:00:00Z",
-                first_committed_at="2023-09-30T10:00:00Z",
+                created_at="2023-10-01T10:00:00+08:00",
+                first_committed_at="2023-09-30T10:00:00+08:00",
                 description="This is a test pull request.",
                 html_url="http://example.com/pr/123",
                 diff_url="http://example.com/diff",
@@ -149,7 +149,7 @@ class TestGithubProvider(unittest.TestCase):
             "user": {"login": "author"},
             "base": {"repo": {"name": "test_repo"}},
             "state": "open",
-            "created_at": "2023-10-01T10:00:00Z",
+            "created_at": "2023-10-01T10:00:00+08:00",
             "body": "This is a test pull request.",
             "html_url": "http://example.com/pr/123",
             "diff_url": "http://example.com/diff",
@@ -159,7 +159,7 @@ class TestGithubProvider(unittest.TestCase):
         }
 
         self.mock_api.pulls.list_commits.return_value = [
-            {"commit": {"author": {"date": "2023-09-30T10:00:00Z"}}}
+            {"commit": {"author": {"date": "2023-09-30T10:00:00+08:00"}}}
         ]
         self.mock_api.pulls.list_reviews.return_value = [
             {"user": {"login": "reviewer1", "type": "User"}}
@@ -176,31 +176,31 @@ class TestGithubProvider(unittest.TestCase):
         mocked_full_page = [  # 7 days from 10/10 ~ 10/16
             {
                 "number": 7,
-                "created_at": "2024-10-16T10:00:00Z",
+                "created_at": "2024-10-16T10:00:00+08:00",
             },
             {
                 "number": 6,
-                "created_at": "2024-10-15T10:00:00Z",
+                "created_at": "2024-10-15T10:00:00+08:00",
             },
             {
                 "number": 5,
-                "created_at": "2024-10-14T10:00:00Z",
+                "created_at": "2024-10-14T10:00:00+08:00",
             },
             {
                 "number": 4,
-                "created_at": "2024-10-13T10:00:00Z",
+                "created_at": "2024-10-13T10:00:00+08:00",
             },
             {
                 "number": 3,
-                "created_at": "2024-10-12T10:00:00Z",
+                "created_at": "2024-10-12T10:00:00+08:00",
             },
             {
                 "number": 2,
-                "created_at": "2024-10-11T10:00:00Z",
+                "created_at": "2024-10-11T10:00:00+08:00",
             },
             {
                 "number": 1,
-                "created_at": "2024-10-10T10:00:00Z",
+                "created_at": "2024-10-10T10:00:00+08:00",
             },
         ]
 
@@ -213,8 +213,8 @@ class TestGithubProvider(unittest.TestCase):
         self.mock_api.pulls.list.side_effect = side_effect
 
         # start and end cover the entire 7 days
-        start = datetime.strptime("2024-10-09T10:00:00Z", "%Y-%m-%dT%H:%M:%SZ")
-        end = datetime.strptime("2024-10-17T10:00:00Z", "%Y-%m-%dT%H:%M:%SZ")
+        start = datetime.strptime("2024-10-09T10:00:00+08:00", "%Y-%m-%dT%H:%M:%S%z")
+        end = datetime.strptime("2024-10-17T10:00:00+08:00", "%Y-%m-%dT%H:%M:%S%z")
 
         pr_numbers = asyncio.run(
             self.github_provider.list_pr_numbers("test_repo", start, end, True)
@@ -235,34 +235,34 @@ class TestGithubProvider(unittest.TestCase):
         mocked_1st_page = [
             {
                 "number": 7,
-                "created_at": "2024-10-16T10:00:00Z",
+                "created_at": "2024-10-16T10:00:00+08:00",
             },
             {
                 "number": 6,
-                "created_at": "2024-10-15T10:00:00Z",
+                "created_at": "2024-10-15T10:00:00+08:00",
             },
             {
                 "number": 5,
-                "created_at": "2024-10-14T10:00:00Z",
+                "created_at": "2024-10-14T10:00:00+08:00",
             },
             {
                 "number": 4,
-                "created_at": "2024-10-13T10:00:00Z",
+                "created_at": "2024-10-13T10:00:00+08:00",
             },
         ]
 
         mocked_2nd_page = [
             {
                 "number": 3,
-                "created_at": "2024-10-12T10:00:00Z",
+                "created_at": "2024-10-12T10:00:00+08:00",
             },
             {
                 "number": 2,
-                "created_at": "2024-10-11T10:00:00Z",
+                "created_at": "2024-10-11T10:00:00+08:00",
             },
             {
                 "number": 1,
-                "created_at": "2024-10-10T10:00:00Z",
+                "created_at": "2024-10-10T10:00:00+08:00",
             },
         ]
 
@@ -277,8 +277,8 @@ class TestGithubProvider(unittest.TestCase):
         self.mock_api.pulls.list.side_effect = side_effect
 
         # start and end cover the entire 7 days
-        start = datetime.strptime("2024-10-09T10:00:00Z", "%Y-%m-%dT%H:%M:%SZ")
-        end = datetime.strptime("2024-10-17T10:00:00Z", "%Y-%m-%dT%H:%M:%SZ")
+        start = datetime.strptime("2024-10-09T10:00:00+08:00", "%Y-%m-%dT%H:%M:%S%z")
+        end = datetime.strptime("2024-10-17T10:00:00+08:00", "%Y-%m-%dT%H:%M:%S%z")
 
         pr_numbers = asyncio.run(
             self.github_provider.list_pr_numbers("rest_repo", start, end, True)
@@ -289,34 +289,34 @@ class TestGithubProvider(unittest.TestCase):
         mocked_1st_page = [
             {
                 "number": 7,
-                "created_at": "2024-10-16T10:00:00Z",
+                "created_at": "2024-10-16T10:00:00+08:00",
             },
             {
                 "number": 6,
-                "created_at": "2024-10-15T10:00:00Z",
+                "created_at": "2024-10-15T10:00:00+08:00",
             },
             {
                 "number": 5,
-                "created_at": "2024-10-14T10:00:00Z",
+                "created_at": "2024-10-14T10:00:00+08:00",
             },
             {
                 "number": 4,
-                "created_at": "2024-10-13T10:00:00Z",
+                "created_at": "2024-10-13T10:00:00+08:00",
             },
         ]
 
         mocked_2nd_page = [
             {
                 "number": 3,
-                "created_at": "2024-10-12T10:00:00Z",
+                "created_at": "2024-10-12T10:00:00+08:00",
             },
             {
                 "number": 2,
-                "created_at": "2024-10-11T10:00:00Z",
+                "created_at": "2024-10-11T10:00:00+08:00",
             },
             {
                 "number": 1,
-                "created_at": "2024-10-10T10:00:00Z",
+                "created_at": "2024-10-10T10:00:00+08:00",
             },
         ]
 
@@ -331,8 +331,8 @@ class TestGithubProvider(unittest.TestCase):
         self.mock_api.pulls.list.side_effect = side_effect
 
         # only covers [10/10 - 10/11] on the 2nd page
-        start = datetime.strptime("2024-10-10T10:00:00Z", "%Y-%m-%dT%H:%M:%SZ")
-        end = datetime.strptime("2024-10-11T10:00:00Z", "%Y-%m-%dT%H:%M:%SZ")
+        start = datetime.strptime("2024-10-10T10:00:00+08:00", "%Y-%m-%dT%H:%M:%S%z")
+        end = datetime.strptime("2024-10-11T10:00:00+08:00", "%Y-%m-%dT%H:%M:%S%z")
 
         pr_numbers = asyncio.run(
             self.github_provider.list_pr_numbers("rest_repo", start, end, True)


### PR DESCRIPTION
1. add a simple `WeeklySummarizer` with some TODOs for later
2. make datetime parsing timezone aware
3. increase `num_ctx` to handle larger PRs
4. remove `PRSummaryMetadata` to be added later

An sample response by running 
```
        weekly_summarizer.run(
            users=["jimmytai", "chihangwang"],
            repo_name="perfeed",
            start_of_week="2024-10-21",
        ) 
```
looks like
```
* fix a bug that caused PRSummarizer to not run properly, by adding `asyncio` import and updating the `PRSummarizer` class.
* add a new feature to refactor git providers to support multiple implementations for the base class with async calls, including adding a `BaseGitProvider` class and refactoring the GithubProvider to use async calls.
* fix another bug that caused PRSummarizer to return a string instead of a typed response, by renaming `PRDescription` to `PRSummary` and updating the return type of `PRSummarizer.run()`.
* add an enhancement to add models directory and reference in prompt str, including adding new Pydantic model classes and updating the prompts to reference them.
```